### PR TITLE
Add support for ** wildcard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _build
 Build
 Makefile.PL
 META.yml
+MYMETA.*


### PR DESCRIPTION
I thought it would be handy to support the `**` wildcard seen in zsh & newer versions of bash.  It's just like `*`, but it can match a `/` (as long as it's not followed by `.`).  Tests are included.
